### PR TITLE
Fixed for dumping error message while opening in chrome

### DIFF
--- a/chrotry
+++ b/chrotry
@@ -184,7 +184,7 @@ def do_action():
     if k == 11:
         url = last_rows[highlight][idx["url"]]
         _ = os.system(
-            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome {} > /tmp/chrotry".format(
+            "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \"{}\" > /tmp/chrotry".format(
                 url
             )
         )


### PR DESCRIPTION
## Summary
As below pic shows, fix bug for dumping error message to terminal directly while open url with special chars (such as `&`) in chrome.

![image](https://user-images.githubusercontent.com/5491423/146145146-08f93573-019f-4def-9c20-a54954ca77dc.png)
